### PR TITLE
Set the proper accepts header for a sparql response

### DIFF
--- a/lib/qa/authorities/getty.rb
+++ b/lib/qa/authorities/getty.rb
@@ -50,8 +50,7 @@ module Qa::Authorities
     end
 
     def request_options
-      # Don't pass a request header. See http://answers.semanticweb.com/questions/31906/getty-sparql-gives-a-404-if-you-pass-accept-applicationjson
-      { }
+      { accept: 'application/sparql-results+json'}
     end
 
     private

--- a/spec/lib/authorities_getty_spec.rb
+++ b/spec/lib/authorities_getty_spec.rb
@@ -81,7 +81,7 @@ describe Qa::Authorities::Getty do
 
   describe "#request_options" do
     subject { authority.request_options }
-    it { is_expected.to eq({}) }
+    it { is_expected.to eq(accept: "application/sparql-results+json") }
   end
 
 end


### PR DESCRIPTION
See
http://answers.semanticweb.com/questions/31906/getty-sparql-gives-a-404-if-you-pass-accept-applicationjson