### PR TITLE
Fix Mesh#search to filter results

### DIFF
--- a/lib/qa/authorities/mesh.rb
+++ b/lib/qa/authorities/mesh.rb
@@ -3,7 +3,7 @@ module Qa::Authorities
 
     def search q
       begin
-        r = Qa::SubjectMeshTerm.where('term_lower LIKE ?', "#{@q}%").limit(10)
+        r = Qa::SubjectMeshTerm.where('term_lower LIKE ?', "#{q}%").limit(10)
         r.map { |t| {id: t.term_id, label: t.term} }
       end
     end

--- a/spec/lib/authorities/mesh_spec.rb
+++ b/spec/lib/authorities/mesh_spec.rb
@@ -30,9 +30,11 @@ describe Qa::Authorities::Mesh do
     let(:m) { Qa::Authorities::Mesh.new }
 
     it "handles queries" do
-      results = m.search('mr')
+      results = m.search('mr ')
+      expect(results.length).to eq(2)
       expect(results).to include( {id: '1', label: 'Mr Plow'} )
-      expect(results.length).to eq(3)
+      expect(results).to include( {id: '2', label: 'Mr Snow'} )
+      expect(results).not_to include( {id: '3', label: 'Mrs Fields'} )
     end
 
     it "returns individual records" do


### PR DESCRIPTION
`Qa::Authorities::Mesh#search` uses a non-existing class variable `@q`
in the `WHERE` clause value. This results in the value of `%` after
interpolation and all records in the table being returned.