### PR TITLE
Change default Faraday parameter encoder

### DIFF
--- a/lib/qa/authorities/loc/generic_authority.rb
+++ b/lib/qa/authorities/loc/generic_authority.rb
@@ -7,7 +7,7 @@ module Qa::Authorities
 
     include WebServiceBase
 
-   def response(url)
+    def response(url)
       uri = URI(url)
       conn = Faraday.new uri.scheme+"://"+uri.host
       conn.options.params_encoder = Faraday::FlatParamsEncoder

--- a/lib/qa/authorities/loc/generic_authority.rb
+++ b/lib/qa/authorities/loc/generic_authority.rb
@@ -7,6 +7,17 @@ module Qa::Authorities
 
     include WebServiceBase
 
+   def response(url)
+      uri = URI(url)
+      conn = Faraday.new uri.scheme+"://"+uri.host
+      conn.options.params_encoder = Faraday::FlatParamsEncoder
+      conn.get do |req|
+        req.headers['Accept'] = 'application/json'        
+        req.url 'search/', :format => "json"
+        req.params = Rack::Utils.parse_query(uri.query)
+      end
+    end
+
     def search q
       @raw_response = get_json(build_query_url(q))
       parse_authority_response

--- a/lib/qa/authorities/web_service_base.rb
+++ b/lib/qa/authorities/web_service_base.rb
@@ -13,6 +13,7 @@ module Qa::Authorities
     def response(url)
       Faraday.get(url) do |req|
         req.headers['Accept'] = 'application/json'
+        req.options.params_encoder = Faraday::FlatParamsEncoder
       end
     end
   end

--- a/lib/qa/authorities/web_service_base.rb
+++ b/lib/qa/authorities/web_service_base.rb
@@ -9,17 +9,11 @@ module Qa::Authorities
       r = response(url).body
       JSON.parse(r)
     end
-
+    
     def response(url)
-      uri = URI(url)
-      conn = Faraday.new uri.scheme+"://"+uri.host
-      conn.options.params_encoder = Faraday::FlatParamsEncoder
-      conn.get do |req|
-        req.headers['Accept'] = 'application/json'        
-        req.url 'search/', :format => "json"
-        req.params = Rack::Utils.parse_query(uri.query)
+      Faraday.get(url) do |req|
+        req.headers['Accept'] = 'application/json'
       end
-
     end
   end
 end

--- a/lib/qa/authorities/web_service_base.rb
+++ b/lib/qa/authorities/web_service_base.rb
@@ -11,10 +11,15 @@ module Qa::Authorities
     end
 
     def response(url)
-      Faraday.get(url) do |req|
-        req.headers['Accept'] = 'application/json'
-        req.options.params_encoder = Faraday::FlatParamsEncoder
+      uri = URI(url)
+      conn = Faraday.new uri.scheme+"://"+uri.host
+      conn.options.params_encoder = Faraday::FlatParamsEncoder
+      conn.get do |req|
+        req.headers['Accept'] = 'application/json'        
+        req.url 'search/', :format => "json"
+        req.params = Rack::Utils.parse_query(uri.query)
       end
+
     end
   end
 end


### PR DESCRIPTION
This changes sets Faraday to use a parameter encoder that does not add any square brackets to repeated query parameters.

This is intended to solve #101 

[Here is a link to the Faraday discussion about this issue.](https://github.com/lostisland/faraday/issues/182)
