### PR TITLE
Adding a special generator and autority for mysql

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,12 @@ Run the generator to install configuration files and an example authority.
     rails generate qa:local:tables
     rake db:migrate
 
+
+  **Note: If you are using MYSQL as your database use the MSQL database generator instead**  
+
+    rails generate qa:local:tables:mysql
+    rake db:migrate
+
 This will create two tables/models Qa::LocalAuthority and Qa::LocalAuthorityEntry. You can then add terms to each:
 
     language_auth = Qa::LocalAuthority.find_or_create_by(name: 'language')
@@ -253,9 +259,13 @@ Unfortunately, Rails doesn't have a mechnism for adding functional indexes to ta
     CREATE INDEX "index_qa_local_authority_entries_on_lower_label" ON 
       "qa_local_authority_entries" (local_authority_id, lower(label))
 
+  **Note: If you are using MYSQL as your database and used the MSQL database gerator we tried to execute the correct SQL to create the virtual fields and indexes for you**  
+
 Finall you want register your authority in an initializer:
 
     Qa::Authorities::Local.register_subauthority('languages', 'Qa::Authorities::Local::TableBasedAuthority')
+
+  **Note: If you are using MYSQL as your database and used the MSQL database gerator register the MysqlTableBasedAuthority instead of the TableBasedAuthority**  
 
 Then you can search for 
 
@@ -268,7 +278,6 @@ Results are in JSON.
 The entire list (up to the first 1000 terms) can also be returned using:
 
     /qa/terms/local/languages/
-
 
 ### Medical Subject Headings (MeSH)
 

--- a/lib/generators/qa/local/tables/mysql/mysql_generator.rb
+++ b/lib/generators/qa/local/tables/mysql/mysql_generator.rb
@@ -1,0 +1,43 @@
+require 'rails/generators/active_record/migration'
+module Qa::Local
+  module Tables
+    class MysqlGenerator < Rails::Generators::Base
+      source_root File.expand_path('../templates', __FILE__)
+      include ActiveRecord::Generators::Migration
+
+      def migrations
+
+        unless defined?(ActiveRecord::ConnectionAdapters::Mysql2Adapter) && ActiveRecord::Base.connection.instance_of?(ActiveRecord::ConnectionAdapters::Mysql2Adapter)
+          message = "Use the table based generator if you are not using mysql 'rails generate qa:local:tables'"
+          say_status("error", message, :red)
+          return 0
+        end
+
+        generate "model qa/local_authority name:string:uniq"
+        generate "model qa/local_authority_entry local_authority:references label:string uri:string:uniq lower_label:string"
+        migration_file = Dir.entries(File.join(destination_root,'db/migrate/'))
+                             .reject{|name| !name.include?('create_qa_local_authority_entries')}.first
+        migration_file = File.join('db/migrate',migration_file)
+        gsub_file migration_file,
+                  't.references :local_authority, index: true, foreign_key: true',
+                  't.integer :local_authority_id, index: true'
+        insert_into_file migration_file, after: "add_index :qa_local_authority_entries, :uri, unique: true" do
+          "\n    add_foreign_key :qa_local_authority_entries, :qa_local_authorities, column: :local_authority_id\n" \
+          "    if ActiveRecord::Base.connection.instance_of? ActiveRecord::ConnectionAdapters::Mysql2Adapter\n"  \
+          "       remove_column :qa_local_authority_entries, :lower_label, :string\n" \
+          "       execute(\"alter table qa_local_authority_entries add lower_label varchar(256) GENERATED ALWAYS AS (lower(label)) VIRTUAL\")\n" \
+          "    end\n" \
+          "    add_index :qa_local_authority_entries, [:lower_label, :local_authority_id], name: 'index_qa_local_authority_entries_on_lower_label_and_authority'"
+        end
+
+        message = "Rails doesn't support functional indexes in migrations, so we inserted an exec into the migration since you are specifying you are running with mysql.\n" \
+                  "The excute will not be run for another database.  The commands being run are: "\
+                  " ALTER TABLE qa_local_authority_entries ADD lower_label VARCHAR(256) GENERATED ALWAYS AS (lower(label)) VIRTUAL" \
+                  " CREATE INDEX index_qa_local_authority_entries_on_lower_label_and_authority ON qa_local_authority_entries (local_authority_id, lower_label)"
+
+        say_status("info", message, :yellow)
+      end
+    end
+  end
+end
+

--- a/lib/generators/qa/local/tables/tables_generator.rb
+++ b/lib/generators/qa/local/tables/tables_generator.rb
@@ -5,6 +5,11 @@ module Qa::Local
     include ActiveRecord::Generators::Migration
 
     def migrations
+      if defined?(ActiveRecord::ConnectionAdapters::Mysql2Adapter) &&  ActiveRecord::Base.connection.instance_of?(ActiveRecord::ConnectionAdapters::Mysql2Adapter)
+        message = "Use the mysql table based generator if you are using mysql 'rails generate qa:local:tables:mysql'"
+        say_status("error", message, :red)
+        return 0
+      end
       generate "model qa/local_authority name:string:uniq"
       generate "model qa/local_authority_entry local_authority:references label:string uri:string:uniq"
       migration_file = Dir.entries(File.join(destination_root,'db/migrate/'))

--- a/lib/qa/authorities/local.rb
+++ b/lib/qa/authorities/local.rb
@@ -5,6 +5,7 @@ module Qa::Authorities
     autoload :FileBasedAuthority
     autoload :Registry
     autoload :TableBasedAuthority
+    autoload :MysqlTableBasedAuthority
 
     def self.config
       @config

--- a/lib/qa/authorities/local/mysql_table_based_authority.rb
+++ b/lib/qa/authorities/local/mysql_table_based_authority.rb
@@ -1,0 +1,23 @@
+module Qa
+  module Authorities
+    module Local
+      #
+      class MysqlTableBasedAuthority < Local::TableBasedAuthority
+        def self.check_for_index
+          conn = ActiveRecord::Base.connection
+          if conn.table_exists?('qa_local_authority_entries') && conn.index_name_exists?(:qa_local_authority_entries, 'index_qa_local_authority_entries_on_lower_label_and_authority', :default).blank?
+            Rails.logger.error "You've installed mysql local authority tables, but you haven't indexed the lower label.  Rails doesn't support functional indexes in migrations, so we tried to execute it for you but something went wrong...\n" \
+              'Make sure your table has a lower_label column which is virtuall created and that column is indexed' \
+              ' ALTER TABLE qa_local_authority_entries ADD lower_label VARCHAR(256) GENERATED ALWAYS AS (lower(label)) VIRTUAL' \
+              ' CREATE INDEX index_qa_local_authority_entries_on_lower_label_and_authority ON qa_local_authority_entries (local_authority_id, lower_label)'
+          end
+        end
+
+        def search(q)
+          return [] if q.blank?
+          output_set(base_relation.where('lower_label like ?', "#{q.downcase}%").limit(25))
+        end
+      end
+    end
+  end
+end

--- a/lib/qa/authorities/local/table_based_authority.rb
+++ b/lib/qa/authorities/local/table_based_authority.rb
@@ -7,6 +7,7 @@ module Qa::Authorities
           "CREATE INDEX \"index_qa_local_authority_entries_on_lower_label\" ON \"qa_local_authority_entries\" (local_authority_id, lower(label))\n" \
           "   OR on Sqlite: \n" \
           "CREATE INDEX \"index_qa_local_authority_entries_on_lower_label\" ON \"qa_local_authority_entries\" (local_authority_id, label collate nocase)\n" \
+          "   OR for MySQL use the MSQLTableBasedAuthority instead, since mysql does not support functional indexes."
       end
     end
 

--- a/spec/lib/authorities/mysql_table_based_authority_spec.rb
+++ b/spec/lib/authorities/mysql_table_based_authority_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe Qa::Authorities::Local::MysqlTableBasedAuthority do
+  let(:language) { Qa::Authorities::Local.subauthority_for("language") }
+  let(:language_auth) { Qa::LocalAuthority.find_by(name: 'language') }
+  let(:base_relation) { Qa::LocalAuthorityEntry.where(name: 'language') }
+  before do
+    Qa::Authorities::Local.register_subauthority('language', described_class.to_s)
+  end
+
+  describe "#check_for_index" do
+    let(:connection) { ActiveRecord::Base.connection }
+    before do
+      allow(ActiveRecord::Base).to receive(:connection).and_return(connection)
+    end
+    context "with no index" do
+      before do
+        #allow(connection).to receive(:index_name_exists?).and_return(nil)
+      end
+      it "outputs an error message" do
+        expect(Rails.logger).to receive(:error)
+        described_class.check_for_index
+      end
+    end
+    context "with index" do
+      before do
+        allow(connection).to receive(:index_name_exists?).and_return(true)
+      end
+      it "outputs an error message" do
+        expect(Rails.logger).not_to receive(:error)
+        described_class.check_for_index
+      end
+    end
+  end
+
+  describe "#search" do
+    context "with an empty query string" do
+      let(:expected) { [] }
+      it "should return no results" do
+        expect(Qa::LocalAuthorityEntry).not_to receive(:where)
+        expect(language.search("")).to eq(expected)
+      end
+    end
+    context "with at least one matching entry" do
+      it "is case insensitive by using lower_lable column" do
+        expect(Qa::LocalAuthorityEntry).to receive(:where).with(local_authority: language_auth).and_return(base_relation)
+        expect(base_relation).to receive(:where).with("lower_label like ?","fre%").and_return(base_relation)
+        expect(base_relation).to receive(:limit).and_return([])
+        language.search("fRe")
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
fixes #105 

Added the correct generator for mysql which includes creating the virtual column for lower_label in mysql syntax.  I believe this is safe since the user is specifically choosing to run the MySQL generator and we have checked their database connection to be certain it is a MySQL connection.