### PR TITLE
Adding rdf authority parser for filling local authority tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,12 @@ Results are in JSON.
 The entire list (up to the first 1000 terms) can also be returned using:
 
     /qa/terms/local/languages/
-
+    
+#### Loading RDF data into database tables
+    
+ You can use the Qa::Services::RDFAuthorityParser to import rdf files into yopur database tables.  See the class file, lib/qa/services/rdf_authority_parser.rb, for examples and more information.
+ To run the class in your local project you must include `gem 'linkeddata'` into your Gemfile and `require 'linkeddata'` into an initializer or your application.rb
+   
 ### Medical Subject Headings (MeSH)
 
 Provides autocompletion of [MeSH terms](http://www.nlm.nih.gov/mesh/introduction.html). This

--- a/lib/qa.rb
+++ b/lib/qa.rb
@@ -6,6 +6,7 @@ module Qa
   extend ActiveSupport::Autoload
 
   autoload :Authorities
+  autoload :Services
 
   # Raised when the configuration directory for local authorities doesn't exist
   class ConfigDirectoryNotFound < StandardError; end

--- a/lib/qa/services.rb
+++ b/lib/qa/services.rb
@@ -1,0 +1,5 @@
+module Qa::Services
+  extend ActiveSupport::Autoload
+
+  autoload :RDFAuthorityParser
+end

--- a/lib/qa/services/rdf_authority_parser.rb
+++ b/lib/qa/services/rdf_authority_parser.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+module Qa
+  module Services
+    # Class to parse downloaded content from rdf sources such as
+    # Library of Congress and Lexvo to create LocalAuthorityEntries
+    # for a named LocalAuthority.
+    #
+    # Example calls:
+    # RDFAuthorityParser.import_rdf('subjects',['/tmp/authoritiessubjects.nt'])
+    # RDFAuthorityParser.import_rdf('languages',['/tmp/lexvo_2013-02-09.rdf'],
+    #        format: 'rdfxml',
+    #        predicate: RDF::URI("http://www.w3.org/2008/05/skos#prefLabel"))
+    #
+    class RDFAuthorityParser
+      class << self
+        # import the rdf from the sources and store them as entries for the
+        # named LocalAuthority
+        #
+        # @param [String] name    The name of the authority to update
+        # @param [Array]  sources An array of file names to process
+        # @param [Hash]   opts    options for processing
+        # @option [opts]  :format     format of the rdf to parse
+        #                              see RDF::Reader for valid options
+        #                             defaults to :ntripples
+        # @option [opts]  :predicate  label predicate to use for
+        #                              LocalAuthorityEntry.label, which
+        #                              must match a field in the source file(s)
+        #                             defaults to http://www.w3.org/2004/02/skos/core#prefLabel
+        def import_rdf(name, sources, opts = {})
+          authority = Qa::LocalAuthority.find_or_create_by(name: name)
+          format = opts.fetch(:format, :ntriples)
+          predicate = opts.fetch(:predicate, ::RDF::Vocab::SKOS.prefLabel)
+          sources.each do |uri|
+            import_source(authority, format, predicate, uri)
+          end
+        end
+
+        private
+
+        def import_source(authority, format, predicate, uri)
+          ::RDF::Reader.open(uri, format: format) do |reader|
+            reader.each_statement do |statement|
+              parse_statement(statement, predicate, authority)
+            end
+          end
+        end
+
+        def parse_statement(statement, predicate, authority)
+          return unless statement.predicate == predicate
+          Qa::LocalAuthorityEntry.create(local_authority: authority,
+                                         label: statement.object.to_s,
+                                         uri: statement.subject.to_s)
+        rescue ActiveRecord::RecordNotUnique
+          Rails.logger.warn("Duplicate record: #{statement.subject}")
+        end
+      end
+    end
+  end
+end

--- a/qa.gemspec
+++ b/qa.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "simplecov"
   s.add_development_dependency "engine_cart", '~> 0.8'
   s.add_development_dependency "byebug"
+  s.add_development_dependency "linkeddata"
 end

--- a/spec/fixtures/lexvo_snippet.rdf
+++ b/spec/fixtures/lexvo_snippet.rdf
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rdf:RDF
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+  xmlns:lvont="http://lexvo.org/ontology#"
+  xmlns:lexvo="http://lexvo.org/id/"
+  xmlns:owl="http://www.w3.org/2002/07/owl#"
+  xmlns:skos="http://www.w3.org/2008/05/skos#"
+  xmlns:skosxl="http://www.w3.org/2008/05/skos-xl#"
+  xmlns:foaf="http://xmlns.com/foaf/0.1/"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema#" >
+
+<!--
+This data file is a part of
+
+Lexvo
+http://www.lexvo.org/
+Gerard de Melo, 2008-2013
+
+License: Creative Commons Attribution-Share Alike 3.0 Unported
+http://creativecommons.org/licenses/by-sa/3.0/
+
+Portions copyright various contributors (e.g. article authors on Wikipedia).
+For information about the data sources and the respective copyrights,
+please see:
+http://www.lexvo.org/linkeddata/sources.html
+-->
+<rdf:Description rdf:about="http://lexvo.org/id/iso639-3/aab">
+  <rdf:type rdf:resource="lvont:Language" />
+  <rdfs:comment xml:lang="en">Alumu (Alumu–Akpondu, Alumu–Tesu) is a Niger–Congo language spoken by approxi
+mately 7000 people in Nassarawa State, Nigeria. It has lost the nominal affix system characteristic of the
+Niger–Congo family.</rdfs:comment>
+  <rdfs:label xml:lang="de">Alumu-Tesu</rdfs:label>
+  <rdfs:label xml:lang="en">Alumu language</rdfs:label>
+  <rdfs:label xml:lang="en">Alumu-Tesu</rdfs:label>
+  <rdfs:label xml:lang="hr">Alumu-Tesu jezik</rdfs:label>
+  <rdfs:label xml:lang="nl">Alumu-Tesu</rdfs:label>
+  <rdfs:label xml:lang="pms">Lenga Alumu-Tesu</rdfs:label>
+  <owl:sameAs rdf:resource="http://dbpedia.org/resource/Alumu_language" />
+  <owl:sameAs rdf:resource="http://www.mpii.de/yago/resource/Alumu_language" />
+  <lvont:iso639P3PCode rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aab</lvont:iso639P3PCode>
+  <lvont:label rdf:resource="http://lexvo.org/id/term/deu/Alumu-Tesu" /> <!-- Alumu-Tesu -->
+  <lvont:label rdf:resource="http://lexvo.org/id/term/eng/Alumu%20language" /> <!-- Alumu language -->
+  <lvont:label rdf:resource="http://lexvo.org/id/term/eng/Alumu-Tesu" /> <!-- Alumu-Tesu -->
+  <lvont:label rdf:resource="http://lexvo.org/id/term/hrv/Alumu-Tesu%20jezik" /> <!-- Alumu-Tesu jezik -->
+  <lvont:label rdf:resource="http://lexvo.org/id/term/nld/Alumu-Tesu" /> <!-- Alumu-Tesu -->
+  <lvont:label rdf:resource="http://lexvo.org/id/term/pms/Lenga%20Alumu-Tesu" /> <!-- Lenga Alumu-Tesu -->
+  <skos:prefLabel xml:lang="en">Alumu-Tesu</skos:prefLabel>
+</rdf:Description>
+<rdf:Description rdf:about="http://lexvo.org/id/iso639-3/aac">
+  <rdf:type rdf:resource="lvont:Language" />
+  <rdfs:comment xml:lang="en">The Ari language is a Papuan language of the Trans–New Guinea family. As of the 2000 census there were only 50 Ari speakers, living in two villages.</rdfs:comment>
+  <rdfs:label xml:lang="en">Ari language</rdfs:label>
+  <rdfs:label xml:lang="en">Ari</rdfs:label>
+  <rdfs:label xml:lang="fr">Ari</rdfs:label>
+  <rdfs:label xml:lang="hr">Ari jezik</rdfs:label>
+  <rdfs:label xml:lang="nl">Ari</rdfs:label>
+  <rdfs:label xml:lang="pms">Lenga Ari</rdfs:label>
+  <owl:sameAs rdf:resource="http://dbpedia.org/resource/Ari_language" />
+  <owl:sameAs rdf:resource="http://www.lingvoj.org/lang/aac" />
+  <owl:sameAs rdf:resource="http://www.mpii.de/yago/resource/Ari_language" />
+  <lvont:iso639P3PCode rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aac</lvont:iso639P3PCode>
+  <lvont:label rdf:resource="http://lexvo.org/id/term/eng/Ari%20language" /> <!-- Ari language -->
+  <lvont:label rdf:resource="http://lexvo.org/id/term/eng/Ari" /> <!-- Ari -->
+  <lvont:label rdf:resource="http://lexvo.org/id/term/fra/Ari" /> <!-- Ari -->
+  <lvont:label rdf:resource="http://lexvo.org/id/term/hrv/Ari%20jezik" /> <!-- Ari jezik -->
+  <lvont:label rdf:resource="http://lexvo.org/id/term/nld/Ari" /> <!-- Ari -->
+  <lvont:label rdf:resource="http://lexvo.org/id/term/pms/Lenga%20Ari" /> <!-- Lenga Ari -->
+  <skos:prefLabel xml:lang="en">Ari</skos:prefLabel>
+</rdf:Description>
+<rdf:Description rdf:about="http://lexvo.org/id/iso639-3/aac">
+  <rdf:type rdf:resource="lvont:Language" />
+  <rdfs:comment xml:lang="en">The Ari language is a Papuan language of the Trans–New Guinea family. As of the 2000 census there were only 50 Ari speakers, living in two villages.</rdfs:comment>
+  <rdfs:label xml:lang="en">Ari language</rdfs:label>
+  <rdfs:label xml:lang="en">Ari</rdfs:label>
+  <rdfs:label xml:lang="fr">Ari</rdfs:label>
+  <rdfs:label xml:lang="hr">Ari jezik</rdfs:label>
+  <rdfs:label xml:lang="nl">Ari</rdfs:label>
+  <rdfs:label xml:lang="pms">Lenga Ari</rdfs:label>
+  <owl:sameAs rdf:resource="http://dbpedia.org/resource/Ari_language" />
+  <owl:sameAs rdf:resource="http://www.lingvoj.org/lang/aac" />
+  <owl:sameAs rdf:resource="http://www.mpii.de/yago/resource/Ari_language" />
+  <lvont:iso639P3PCode rdf:datatype="http://www.w3.org/2001/XMLSchema#string">aac</lvont:iso639P3PCode>
+  <lvont:label rdf:resource="http://lexvo.org/id/term/eng/Ari%20language" /> <!-- Ari language -->
+  <lvont:label rdf:resource="http://lexvo.org/id/term/eng/Ari" /> <!-- Ari -->
+  <lvont:label rdf:resource="http://lexvo.org/id/term/fra/Ari" /> <!-- Ari -->
+  <lvont:label rdf:resource="http://lexvo.org/id/term/hrv/Ari%20jezik" /> <!-- Ari jezik -->
+  <lvont:label rdf:resource="http://lexvo.org/id/term/nld/Ari" /> <!-- Ari -->
+  <lvont:label rdf:resource="http://lexvo.org/id/term/pms/Lenga%20Ari" /> <!-- Lenga Ari -->
+  <skos:prefLabel xml:lang="en">Ari</skos:prefLabel>
+</rdf:Description>

--- a/spec/lib/services/rdf_authority_parser_spec.rb
+++ b/spec/lib/services/rdf_authority_parser_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe Qa::Services::RDFAuthorityParser do
+  let(:source) {[File.join(fixture_path,'lexvo_snippet.rdf')] }
+  let(:format) { 'rdfxml' }
+  let(:predicate) { RDF::URI("http://www.w3.org/2008/05/skos#prefLabel") }
+  let(:name) { 'language' }
+  let(:alum_entry) { Qa::LocalAuthorityEntry.find_by(label: 'Alumu-Tesu') }
+  let(:ari_entry) { Qa::LocalAuthorityEntry.find_by(label: 'Ari') }
+
+  describe "#import_rdf" do
+    before do
+      blah = Qa::LocalAuthority.find_by_name(name)
+      described_class.import_rdf(name, source, format: format, predicate: predicate)
+    end
+    it "creates the authority and authority entries" do
+      expect(Qa::LocalAuthority.count).to eq(1)
+      expect(Qa::LocalAuthority.find_by(name: name)).not_to be_nil
+      expect(Qa::LocalAuthorityEntry.count).to eq(2)
+      expect(alum_entry).not_to be_nil
+      expect(alum_entry.uri).to eq('http://lexvo.org/id/iso639-3/aab')
+      expect(ari_entry).not_to be_nil
+      expect(ari_entry.uri).to eq('http://lexvo.org/id/iso639-3/aac')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 
+require 'linkeddata'
+
 require 'engine_cart'
 require 'simplecov'
 require 'byebug' unless ENV['TRAVIS']
@@ -18,7 +20,7 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
 RSpec.configure do |config|
 
-  config.fixture_path = "../spec/fixtures"
+  config.fixture_path =  File.expand_path("../fixtures", __FILE__)
 
   config.use_transactional_fixtures = true
 


### PR DESCRIPTION
This PR resurrects code from ScholarSphere that parses the downloadable files from Library of Congress and Lexvo to fill in the local authority tables.

