### PR TITLE
Avoid using deprecated method #table_exists?

### DIFF
--- a/lib/qa/authorities/local/mysql_table_based_authority.rb
+++ b/lib/qa/authorities/local/mysql_table_based_authority.rb
@@ -5,7 +5,7 @@ module Qa
       class MysqlTableBasedAuthority < Local::TableBasedAuthority
         def self.check_for_index
           conn = ActiveRecord::Base.connection
-          if conn.table_exists?('qa_local_authority_entries') && conn.index_name_exists?(:qa_local_authority_entries, 'index_qa_local_authority_entries_on_lower_label_and_authority', :default).blank?
+          if table_or_view_exists? && conn.index_name_exists?(:qa_local_authority_entries, 'index_qa_local_authority_entries_on_lower_label_and_authority', :default).blank?
             Rails.logger.error "You've installed mysql local authority tables, but you haven't indexed the lower label.  Rails doesn't support functional indexes in migrations, so we tried to execute it for you but something went wrong...\n" \
               'Make sure your table has a lower_label column which is virtuall created and that column is indexed' \
               ' ALTER TABLE qa_local_authority_entries ADD lower_label VARCHAR(256) GENERATED ALWAYS AS (lower(label)) VIRTUAL' \


### PR DESCRIPTION
Rails 5 gives the deprecation warning:
```
DEPRECATION WARNING: #table_exists? currently checks both tables and
views. This behavior is deprecated and will be changed with Rails 5.1 to
only check tables. Use #data_source_exists? instead.
```