### PR TITLE
Loosen nokogiri dependency

### DIFF
--- a/qa.gemspec
+++ b/qa.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", ">= 4.2.0", "< 6.0"
   s.add_dependency "faraday"
-  s.add_dependency "nokogiri", "~> 1.6.0"
+  s.add_dependency "nokogiri", "~> 1.6"
   s.add_dependency "activerecord-import"
   s.add_dependency "deprecation"
 

--- a/qa.gemspec
+++ b/qa.gemspec
@@ -31,5 +31,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "webmock"
   s.add_development_dependency 'rubocop', '~> 0.42.0'
-  s.add_development_dependency 'rubocop-rspec', '~> 1.5'
+  s.add_development_dependency 'rubocop-rspec', '~> 1.8.0'
 end


### PR DESCRIPTION
Rubocop 1.7.0 is out now.

 Pin rubocop-rspec to 1.8.0 so as to avoid the newer cops in 1.9.0