### PR TITLE
Make `Authorities::Base` explicitly abstract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ Gemfile.lock
 coverage
 pkg
 .internal_test_app
+
+/doc
+.yardoc

--- a/app/controllers/qa/terms_controller.rb
+++ b/app/controllers/qa/terms_controller.rb
@@ -9,7 +9,11 @@ class Qa::TermsController < ApplicationController
 
   # If the subauthority supports it, return a list of all terms in the authority
   def index
-    render json: @authority.all
+    render json: begin
+      @authority.all
+    rescue NotImplementedError
+      nil
+    end
   end
 
   # Return a list of terms based on a query

--- a/lib/qa/authorities/base.rb
+++ b/lib/qa/authorities/base.rb
@@ -13,8 +13,11 @@ module Qa::Authorities
     #   implement this method to conform to the generic interface.
     #
     # @return [Enumerable]
+    # @raise [NotImplementedError] when this method is abstract.
+    #
     # @todo better specify return type
     def all
+      raise NotImplementedError, "#{self.class}#all is unimplemented."
     end
 
     ##
@@ -24,8 +27,11 @@ module Qa::Authorities
     # @param id [String] the id string for the authority to lookup
     #
     # @return [Hash]
+    # @raise [NotImplementedError] when this method is abstract.
+    #
     # @todo better specify return type
     def find(_id)
+      raise NotImplementedError, "#{self.class}#all is unimplemented."
     end
 
     ##

--- a/lib/qa/authorities/base.rb
+++ b/lib/qa/authorities/base.rb
@@ -1,25 +1,37 @@
 require 'deprecation'
 
 module Qa::Authorities
+  ##
+  # @abstract The base class for all authorites. Implementing subclasses must
+  #   provide {#all} and #{find} methods.
+  # @todo What about {#search}?
   class Base
     extend Deprecation
 
-    # By default, #all is not implemented.
-    # If the subclassed authority does have this feature
-    # then you will overide the #all method in the subclassed authority.
-    # TODO: need to set some kind of error here
+    ##
+    # @abstract By default, #all is not implemented. A subclass authority must
+    #   implement this method to conform to the generic interface.
+    #
+    # @return [Enumerable]
+    # @todo better specify return type
     def all
     end
 
-    # By default, #find is not implemented.
-    # If the subclassed authority does have this feature
-    # then you will overide the #find method in the subclassed authority.
-    # TODO: need to set some kind of error here
-    def find(id)
+    ##
+    # @abstract By default, #find is not implemented. A subclass authority must
+    #   implement this method to conform to the generic interface.
+    #
+    # @param id [String] the id string for the authority to lookup
+    #
+    # @return [Hash]
+    # @todo better specify return type
+    def find(_id)
     end
 
+    ##
+    # @deprecated use {#find} instead
     def full_record(id, _subauthority = nil)
-      Deprecation.warn(".full_record is deprecated. Use .find instead")
+      Deprecation.warn('#full_record is deprecated. Use #find instead')
       find(id)
     end
   end

--- a/spec/lib/authorities/base_spec.rb
+++ b/spec/lib/authorities/base_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Qa::Authorities::Base do
+  describe '#all' do
+    it 'is unimplemeted' do
+      expect { subject.all }.to raise_error NotImplementedError
+    end
+  end
+
+  describe '#find' do
+    it 'is unimplemeted' do
+      expect { subject.find('moomin') }.to raise_error NotImplementedError
+    end
+  end
+end


### PR DESCRIPTION
Fixes a pair of TODO items in `Authorities::Base`. A minor adjustment is made to the terms controller to catch the new errors. 

Full implementations of the Authority interface should be unchanged; for partial implementations this may reveal bugs.

----

The first commit (9a7318e) adds some documentation for the `Authorities::Base` class. A few major ToDo items remain. Quoting from the commit message:

> A few details are missing, as I'm not sure the interface is actually very clearly defined. Questions:
>
>   - Is there a return type for `#find(id)`? Possibly `Hash` or
>     `#to_json`?
>   - Does `#all` return an `Enumerable<Hash/#to_json>` or `Array`?
>   - Is `#search` a required method?
>
> If I find obvious answers to these, or come up with a proposal, I'll update as needed.