### PR TITLE
Require `activesupport/core_ext` from authorities

### DIFF
--- a/lib/qa/authorities.rb
+++ b/lib/qa/authorities.rb
@@ -1,3 +1,6 @@
+require 'active_support'
+require 'active_support/core_ext'
+
 module Qa::Authorities
   extend ActiveSupport::Autoload
 


### PR DESCRIPTION
This makes it possible for client code to depend on authorities without introducing the entire engine (and therefore rails).