### PR TITLE
Deprecate `WebServiceBase#get_json`; use `#json`

### DIFF
--- a/lib/qa/authorities/assign_fast/generic_authority.rb
+++ b/lib/qa/authorities/assign_fast/generic_authority.rb
@@ -27,7 +27,7 @@ module Qa::Authorities
     def search(q)
       url = build_query_url q
       begin
-        raw_response = get_json(url)
+        raw_response = json(url)
       rescue JSON::ParserError
         Rails.logger.info "Could not parse response as JSON. Request url: #{url}"
         return []

--- a/lib/qa/authorities/geonames.rb
+++ b/lib/qa/authorities/geonames.rb
@@ -16,11 +16,6 @@ module Qa::Authorities
       parse_authority_response(json(build_query_url(q)))
     end
 
-    # get_json is not ideomatic, so we'll make an alias
-    def json(*args)
-      get_json(*args)
-    end
-
     def build_query_url(q)
       query = URI.escape(untaint(q))
       "http://api.geonames.org/searchJSON?q=#{query}&username=#{username}&maxRows=10"

--- a/lib/qa/authorities/getty/aat.rb
+++ b/lib/qa/authorities/getty/aat.rb
@@ -6,11 +6,6 @@ module Qa::Authorities
       parse_authority_response(json(build_query_url(q)))
     end
 
-    # get_json is not ideomatic, so we'll make an alias
-    def json(*args)
-      get_json(*args)
-    end
-
     def build_query_url(q)
       "http://vocab.getty.edu/sparql.json?query=#{URI.escape(sparql(q))}&_implicit=false&implicit=true&_equivalent=false&_form=%2Fsparql"
     end

--- a/lib/qa/authorities/getty/tgn.rb
+++ b/lib/qa/authorities/getty/tgn.rb
@@ -6,11 +6,6 @@ module Qa::Authorities
       parse_authority_response(json(build_query_url(q)))
     end
 
-    # get_json is not ideomatic, so we'll make an alias
-    def json(*args)
-      get_json(*args)
-    end
-
     def build_query_url(q)
       query = URI.escape(sparql(untaint(q)))
       # Replace ampersands, otherwise the query will fail

--- a/lib/qa/authorities/getty/ulan.rb
+++ b/lib/qa/authorities/getty/ulan.rb
@@ -6,11 +6,6 @@ module Qa::Authorities
       parse_authority_response(json(build_query_url(q)))
     end
 
-    # get_json is not ideomatic, so we'll make an alias
-    def json(*args)
-      get_json(*args)
-    end
-
     # Replace ampersands, otherwise the query will fail
     def build_query_url(q)
       "http://vocab.getty.edu/sparql.json?query=#{URI.escape(sparql(q)).gsub('&', '%26')}&_implicit=false&implicit=true&_equivalent=false&_form=%2Fsparql"

--- a/lib/qa/authorities/loc/generic_authority.rb
+++ b/lib/qa/authorities/loc/generic_authority.rb
@@ -8,7 +8,7 @@ module Qa::Authorities
     include WebServiceBase
 
     def search(q)
-      @raw_response = get_json(build_query_url(q))
+      @raw_response = json(build_query_url(q))
       parse_authority_response
     end
 
@@ -19,7 +19,7 @@ module Qa::Authorities
     end
 
     def find(id)
-      get_json(find_url(id))
+      json(find_url(id))
     end
 
     def find_url(id)

--- a/lib/qa/authorities/web_service_base.rb
+++ b/lib/qa/authorities/web_service_base.rb
@@ -1,19 +1,38 @@
 require 'faraday'
 
 module Qa::Authorities
+  ##
+  # Mix-in to retreive and parse JSON content from the web with Faraday.
   module WebServiceBase
+    ##
+    # @!attribute [rw] raw_response
     attr_accessor :raw_response
 
-    # mix-in to retreive and parse JSON content from the web
-    def get_json(url)
+    ##
+    # Make a web request & retieve a JSON response for a given URL.
+    #
+    # @param url [String]
+    # @return [Hash] a parsed JSON response
+    def json(url)
       r = response(url).body
       JSON.parse(r)
     end
 
+    ##
+    # @deprecated Use #json instead
+    def get_json(url)
+      warn '[DEPRECATED] #get_json is deprecated; use #json instead.' \
+           "Called from #{Gem.location_of_caller.join(':')}."
+      json(url)
+    end
+
+    ##
+    # Make a web request and retrieve the response.
+    #
+    # @param url [String]
+    # @return [Faraday::Response]
     def response(url)
-      Faraday.get(url) do |req|
-        req.headers['Accept'] = 'application/json'
-      end
+      Faraday.get(url) { |req| req.headers['Accept'] = 'application/json' }
     end
   end
 end


### PR DESCRIPTION
Many implementations already overrode `#get_json` with `#json`, since the former is not idiomatic. This simply deprecates the `#get_json` option in favor of a base `#json`.