### PR TITLE
refactors nedhenry's patch to use flat params with LOC

### DIFF
--- a/lib/qa/authorities/loc/generic_authority.rb
+++ b/lib/qa/authorities/loc/generic_authority.rb
@@ -7,6 +7,17 @@ module Qa::Authorities
 
     include WebServiceBase
 
+    def response(url)
+      uri = URI(url)
+      conn = Faraday.new "#{uri.scheme}://#{uri.host}"
+      conn.options.params_encoder = Faraday::FlatParamsEncoder
+      conn.get do |req|
+        req.headers['Accept'] = 'application/json'
+        req.url uri.path
+        req.params = Rack::Utils.parse_query(uri.query)
+      end
+    end
+
     def search(q)
       @raw_response = json(build_query_url(q))
       parse_authority_response


### PR DESCRIPTION
Ran into the issue with needing `Faraday::FlatParamsEncoder`. See #101 
Ned's original PR #102 needed a slight change for the tests to work, and then a manual test on my code confirmed that LOC subject searching works as expected. 

QA + Faraday produces a proper looking url like: 
http://id.loc.gov/search/?format=json&q=Giant+panda--Breeding&q=cs%3Ahttp%3A%2F%2Fid.loc.gov%2Fauthorities%2Fsubjects&

Thanks Ned!