### PR TITLE
Faraday params fix

### DIFF
--- a/lib/qa/authorities/web_service_base.rb
+++ b/lib/qa/authorities/web_service_base.rb
@@ -32,6 +32,7 @@ module Qa::Authorities
     # @param url [String]
     # @return [Faraday::Response]
     def response(url)
+      Faraday::Utils.default_params_encoder = Faraday::FlatParamsEncoder
       Faraday.get(url) { |req| req.headers['Accept'] = 'application/json' }
     end
   end


### PR DESCRIPTION
A fix for issue #133

If you don't have Faraday  use the FlatParamsEncoder it won't use a duplicate param in a request:

?q=china&q=something will become
?q=&q=something