### PR TITLE
update tables_generator references qa_local_authority

### DIFF
--- a/lib/generators/qa/local/tables/tables_generator.rb
+++ b/lib/generators/qa/local/tables/tables_generator.rb
@@ -11,14 +11,7 @@ module Qa::Local
         return 0
       end
       generate "model qa/local_authority name:string:uniq"
-      generate "model qa/local_authority_entry local_authority:references label:string uri:string:uniq"
-      migration_file = Dir.entries(File.join(destination_root, 'db/migrate/'))
-                          .reject { |name| !name.include?('create_qa_local_authority_entries') }.first
-      migration_file = File.join('db/migrate', migration_file)
-      gsub_file migration_file,
-                't.references :local_authority, index: true, foreign_key: true',
-                't.references :local_authority, foreign_key: { to_table: :qa_local_authorities }, index: true'
-
+      generate "model qa/local_authority_entry qa_local_authority:references label:string uri:string:uniq"
       message = "Rails doesn't support functional indexes in migrations, so you'll have to add this manually:\n" \
     "CREATE INDEX \"index_qa_local_authority_entries_on_lower_label\" ON \"qa_local_authority_entries\" (local_authority_id, lower(label))\n" \
     "   OR on Sqlite: \n" \


### PR DESCRIPTION
fixes #130 

Ran into this causing me problems with a fresh Hyrax 1.0.0 alpha app, and did some testing to address the references line in the migration. Here's some console output to see what it did:

```
.internal_test_app master % rails g model qa/bleet_bleet_entries qa_local_authority:references label:string uri:string:uniq
[WARNING] The model name 'qa/bleet_bleet_entries' was recognized as a plural, using the singular 'qa/bleet_bleet_entry' instead. Override with --force-plural or setup custom inflection rules for this noun before running the generator.
      invoke  active_record
      create    db/migrate/20170317185708_create_qa_bleet_bleet_entries.rb
      create    app/models/qa/bleet_bleet_entry.rb
   identical    app/models/qa.rb
      invoke    test_unit
      create      test/models/qa/bleet_bleet_entry_test.rb
      create      test/fixtures/qa/bleet_bleet_entries.yml
.internal_test_app master % cat db/migrate/20170317185708_create_qa_bleet_bleet_entries.rb
class CreateQaBleetBleetEntries < ActiveRecord::Migration[5.0]
  def change
    create_table :qa_bleet_bleet_entries do |t|
      t.references :qa_local_authority, foreign_key: true
      t.string :label
      t.string :uri

      t.timestamps
    end
    add_index :qa_bleet_bleet_entries, :uri, unique: true
  end
end

.internal_test_app master % bundle exec rake db:migrate
== 20170317185708 CreateQaBleetBleetEntries: migrating ========================
-- create_table(:qa_bleet_bleet_entries)
   -> 0.0039s
-- add_index(:qa_bleet_bleet_entries, :uri, {:unique=>true})
   -> 0.0008s
== 20170317185708 CreateQaBleetBleetEntries: migrated (0.0048s) ===============

```